### PR TITLE
feat(populatedb): populate database with script

### DIFF
--- a/db/pool.js
+++ b/db/pool.js
@@ -3,7 +3,7 @@ require("dotenv").config();
 const { Pool } = require("pg");
 
 module.exports = new Pool({
-	connectionString: process.env.PG_DATABASE_URL,
+	connectionString: process.env.PROD_DB_URL,
 	ssl: {
 		require: true,
 	},

--- a/db/populatedb.js
+++ b/db/populatedb.js
@@ -18,9 +18,16 @@ VALUES
 `;
 
 async function main() {
+	const databaseUrl = process.argv[2];
+	if (typeof databaseUrl === "undefined" || databaseUrl === "") {
+		throw new Error(
+			"Database URL not provided. Defaulting to production database.",
+		);
+	}
+
 	console.log("seeding...");
 	const client = new Client({
-		connectionString: process.env.PG_DATABASE_URL,
+		connectionString: databaseUrl,
 	});
 
 	await client.connect();


### PR DESCRIPTION
includes populating both:
* development db, and
* production db

using
```bash
npm run seed-db <db-url>
```

by creating the `messages` table, and then populating it with some fake data

however, the `pg.pool` connects to the _production_ database to allow debugging to be easier. If this is not good practice, I can fix in future (I couldn't find anything on Google that provides guidance)